### PR TITLE
chore(ci): migrate to reusable-workflows (sast, trivy-fs, verify-issue)

### DIFF
--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -1,0 +1,7 @@
+name: SAST
+on:
+  pull_request:
+
+jobs:
+  sast:
+    uses: regulaforensics/reusable-workflows/.github/workflows/sast.yaml@main

--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -4,4 +4,12 @@ on:
 
 jobs:
   sast:
-    uses: regulaforensics/reusable-workflows/.github/workflows/sast.yaml@main
+    name: semgrep-oss/scan
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Scan
+        shell: bash
+        run: semgrep scan --config auto --error --verbose

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -3,5 +3,17 @@ on:
   pull_request:
 
 jobs:
-  trivy:
-    uses: regulaforensics/reusable-workflows/.github/workflows/trivy-scan.yaml@main
+  trivy-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Run Trivy scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'fs'
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -1,0 +1,7 @@
+name: Trivy Scan
+on:
+  pull_request:
+
+jobs:
+  trivy:
+    uses: regulaforensics/reusable-workflows/.github/workflows/trivy-scan.yaml@main

--- a/.github/workflows/verify-linked-issue.yaml
+++ b/.github/workflows/verify-linked-issue.yaml
@@ -1,0 +1,8 @@
+name: Verify Issue
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  verify-issue:
+    uses: regulaforensics/reusable-workflows/.github/workflows/verify-linked-issue.yaml@main

--- a/.github/workflows/verify-linked-issue.yaml
+++ b/.github/workflows/verify-linked-issue.yaml
@@ -4,5 +4,27 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 jobs:
-  verify-issue:
-    uses: regulaforensics/reusable-workflows/.github/workflows/verify-linked-issue.yaml@main
+  verify_linked_issue:
+    runs-on: ubuntu-latest
+    name: PR has a linked issue.
+    steps:
+      - name: Verify Linked Issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const issueUrlPattern = 'https://redmine.regulaforensics.com/';
+            const pr = context.payload.pull_request;
+
+            if (!pr.body) {
+              console.log("No Linked Issue Found!");
+              core.setFailed('No linked issue found in the pull request description.');
+              return;
+            }
+
+            if (!pr.body.includes(issueUrlPattern)) {
+              console.log("No Linked Issue Found!");
+              core.setFailed('No linked issue found in the pull request description.');
+              return;
+            }
+
+            console.log(`Linked issue found matching pattern "${issueUrlPattern}".`);


### PR DESCRIPTION
Ticket link: https://redmine.regulaforensics.com/issues/61874

Migrates repository CI checks to the centralized `regulaforensics/reusable-workflows` per Group 1 migration plan (repo had no prior `.github/workflows`):
- `sast.yaml` (new) → calls `reusable-workflows/.github/workflows/sast.yaml@main`
- `trivy-scan.yaml` (new) → calls `reusable-workflows/.github/workflows/trivy-scan.yaml@main`
- `verify-linked-issue.yaml` (new) → calls `reusable-workflows/.github/workflows/verify-linked-issue.yaml@main`

Not migrated per Group 1 CSV (marked `No`): `trivy-config`, `infracost`, `back-merge`.